### PR TITLE
 fix potential byte overflow exceptions

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -230,10 +230,10 @@ class SDCard:
         # create and send the command
         buf = self._cmdbuf
         buf[0] = 0x40 | cmd
-        buf[1] = arg >> 24
-        buf[2] = arg >> 16
-        buf[3] = arg >> 8
-        buf[4] = arg
+        buf[1] = (arg >> 24) & 0xff
+        buf[2] = (arg >> 16) & 0xff
+        buf[3] = (arg >> 8) & 0xff
+        buf[4] = arg & 0xff
         buf[5] = crc
 
         with self._spi as spi:


### PR DESCRIPTION
This appears to fix #17 
I intentionally only added "& 0xff" where values are manipulated -- arguments passed into functions are assumed to be <= 0xff and need not be tested. If they are not, it is a legitimate error (e.g. crc, cmd, token)  Is that correct od should we wrap everything in () & 0xff? 

Tested on PyPortal and feather_nrf52840_express (with tot featherwing) -- ran slideshow from SD Card.