### PR TITLE
Fixed Issue 13, Samsung EVO 32GB cards not working

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -153,7 +153,7 @@ class SDCard:
         # get the number of sectors
         # CMD9: response R2 (R1 byte + 16-byte block read)
         csd = bytearray(16)
-        if self._cmd(9, response_buf=csd) != 0:
+        if self._cmd(9, 0, 0xaf, response_buf=csd) != 0:
             raise OSError("no response from SD card")
         #self.readinto(csd)
         csd_version = (csd[0] & 0xc0) >> 6
@@ -169,7 +169,7 @@ class SDCard:
             self._sectors = block_length // 512 * mult * (c_size + 1)
 
         # CMD16: set block length to 512 bytes
-        if self._cmd(16, 512, 0) != 0:
+        if self._cmd(16, 512, 0x81) != 0:
             raise OSError("can't set 512 block size")
 
         # set to high data rate now that it's initialised
@@ -190,10 +190,10 @@ class SDCard:
         ocr = bytearray(4)
         for _ in range(_CMD_TIMEOUT):
             time.sleep(.050)
-            self._cmd(58, response_buf=ocr, data_block=False)
-            self._cmd(55)
-            if self._block_cmd(41, 0x200000, 0) == 0:
-                self._cmd(58, response_buf=ocr, data_block=False)
+            self._cmd(58, 0, 0xfd, response_buf=ocr, data_block=False)
+            self._cmd(55, 0, 0x65)
+            if self._cmd(41, 0x40000000, 0x77) == 0:
+                self._cmd(58, 0, 0xfd, response_buf=ocr, data_block=False)
 
                 # Check for block addressing
                 if (ocr[0] & 0x40) != 0:
@@ -405,18 +405,18 @@ class SDCard:
             # CMD17: set read address for single block
             # We use _block_cmd to read our data so that the chip select line
             # isn't toggled between the command, response and data.
-            if self._block_cmd(17, start_block, 0, response_buf=buf) != 0:
+            if self._block_cmd(17, start_block, 0x3b, response_buf=buf) != 0:
                 return 1
         else:
             # CMD18: set read address for multiple blocks
-            if self._block_cmd(18, start_block, 0) != 0:
+            if self._block_cmd(18, start_block, 0x57) != 0:
                 return 1
             offset = 0
             while nblocks:
                 self._readinto(buf, start=offset, end=(offset + 512))
                 offset += 512
                 nblocks -= 1
-            return self._cmd(12, wait=False)
+            return self._cmd(12, 0, 0x09, wait=False)
         return 0
 
     def writeblocks(self, start_block, buf):
@@ -430,14 +430,14 @@ class SDCard:
         assert nblocks and not err, 'Buffer length is invalid'
         if nblocks == 1:
             # CMD24: set write address for single block
-            if self._block_cmd(24, start_block, 0) != 0:
+            if self._block_cmd(24, start_block, 0x6f) != 0:
                 return 1
 
             # send the data
             self._write(_TOKEN_DATA, buf)
         else:
             # CMD25: set write address for first block
-            if self._block_cmd(25, start_block, 0) != 0:
+            if self._block_cmd(25, start_block, 0x03) != 0:
                 return 1
             # send the data
             offset = 0


### PR DESCRIPTION
The issue is that Samsung  EVO 32GB cards require all command codes to have a valid CRC.   I used https://github.com/hazelnusse/crc7/blob/master/crc7.cc  to calculate all CRC codes and it is now working.  On line 195 I also changed one command from a  _block_cmd to a _cmd. It would hang otherwise.  This works for my SanDisk 16 GB card which worked before the fix as well and also works on my Samsung EVO 32GB.  Please test this with all cards.  The spec does say that by default all command code CRC values are ignored except CM0, CMD8 and I believe ACMD41..  It's just that Samsung decided to ignore the default and check all command CRC values.. I was not even able to force it off.