### PR TITLE
Avoid a longint as a cmd arg

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -245,7 +245,7 @@ class SDCard:
             # arg can be a 4-byte buf
             buf[1:5] = arg
         else:
-            raise ValueError("bad arg")
+            raise ValueError()
 
         if (crc == 0):
             buf[5] = calculate_crc(buf[:-1])


### PR DESCRIPTION
This fixes #27.

PR #26 introduced a longint as a cmd arg, which makes the library fail on non-longint builds, such as Feather M0 Adalogger. I reworked the `_cmd()` method to take either an integer or a `bytes`, so non-longint constants can be expressed in the code.

@michelkluger, would you like to test? I can supply a .mpy if you need one.

