### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -94,6 +94,7 @@ class SDCard:
 
     """
 
+    # pylint: disable=invalid-name
     def __init__(self, spi: SPI, cs: DigitalInOut, baudrate: int = 1320000) -> None:
         # Create an SPIDevice running at a lower initialization baudrate first.
         self._spi = spi_device.SPIDevice(spi, cs, baudrate=250000, extra_clocks=8)


### PR DESCRIPTION
Fixes the following `pylint` errors:

```

************* Module adafruit_sdcard
Error: adafruit_sdcard.py:97:33: C0103: Argument name "cs" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```

Issue created to track the `cs` argument name disable.