### PR TITLE
Fix for occasional write hangs

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -500,6 +500,7 @@ class SDCard:
                     )
                     offset += 512
                     nblocks -= 1
+                self._wait_for_ready(card)
                 self._cmd_nodata(card, _TOKEN_STOP_TRAN, 0x0)
         return 0
 


### PR DESCRIPTION
I believe this fixes #50  the write hangs were happening because the SD card wasn't ready for the end block write command. This adds a _wait_for_ready call before the command is sent.

I'm not sure if the _wait_for_ready function is the right one for the desired delay but my test programs all work at any records length once this change is made.