### PR TITLE
Fix example used in the docs

### DIFF
--- a/adafruit_sdcard.py
+++ b/adafruit_sdcard.py
@@ -84,14 +84,16 @@ class SDCard:
         import busio
         import storage
         import adafruit_sdcard
+        import digitalio
         import os
         import board
 
         spi = busio.SPI(SCK, MOSI, MISO)
-        sd = adafruit_sdcard.SDCard(spi, board.SD_CS)
+        cs = digitalio.DigitalInOut(board.SD_CS)
+        sdcard = adafruit_sdcard.SDCard(spi, cs)
         vfs = storage.VfsFat(sdcard)
         storage.mount(vfs, '/sd')
-        os.listdir('/')
+        os.listdir('/sd')
 
     """
 


### PR DESCRIPTION
This is the example displayed at https://docs.circuitpython.org/projects/sd/en/stable/api.html#adafruit_sdcard.SDCard

I fixed it so it's correct (cs is a DigitalInOut and sd -> sdcard) and closer to https://github.com/adafruit/Adafruit_CircuitPython_SD/blob/main/examples/sd_read_simpletest.py#L21